### PR TITLE
Compile against java 7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,9 @@ apply plugin: 'java'
 apply plugin: 'idea'
 apply plugin: 'eclipse'
 
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
+
 repositories {
     jcenter()
 }


### PR DESCRIPTION
Set compiler level to java 7. Else the jar won't be runnable on machines where java 8 is not available yet.

Specifically, tried to run my jar from desktop on other machine, and sadly no java 8 available/installable.